### PR TITLE
simplify script parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ conda install -c ebi-gene-expression-group atlas-data-import
 get_experiment_data.R\
             --accesssion-code <accession code of the data set to be extracted>\
             --config-file <path to config file in .yaml format>\
-            --expr-data-type <type of expression data to download>\
-            --normalisation-method <normalisation method ('TPM' or 'CPM')>\
+            --matrix-type <type of expression data to download>\
             --decorated-rows <boolean; use decorated row names?>\
             --output-dir-name <name of the output directory>\
             --use-default-names <should default names be used?>\

--- a/data_import_post_install_tests.bats
+++ b/data_import_post_install_tests.bats
@@ -7,8 +7,7 @@
 
     run rm -rf output_dir_name'/*' && get_experiment_data.R\
                                         --accesssion-code $study_accession_num\
-                                        --expr-data-type $expr_data_type\
-                                        --normalisation-method $normalisation_method\
+                                        --matrix-type $matrix_type\
                                         --output-dir-name $output_dir_name\
                                         --get-sdrf\
                                         --get-condensed-sdrf\

--- a/data_import_post_install_tests.sh
+++ b/data_import_post_install_tests.sh
@@ -40,11 +40,10 @@ fi
 ################################################################################
 # List tool outputs/ inputs
 ################################################################################
-export study_accession_num="E-ENAD-16"
-export expr_data_type="normalised"
-export normalisation_method="tpm"
-export output_dir_name=$test_dir
-export num_clusters=13
+export study_accession_num="E-ENAD-14"
+export matrix_type="cpm"
+export output_dir_name=$test_dir/$study_accession_num
+export num_clusters=24
 
 ################################################################################
 # Test individual scripts


### PR DESCRIPTION
This PR simplifies the parameters for data import. Instead of having two separate parameters for matrix type and normalisation method, we only keep matrix type, which now includes four options: 'raw', 'filtered', 'cpm', and 'tpm'. 