### PR TITLE
Add retries to classifier downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install:
 before_script:
   - export PATH=`pwd`:$PATH
 
-script: data_import_post_install_tests.sh
+script: travis_wait 30 data_import_post_install_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install:
 before_script:
   - export PATH=`pwd`:$PATH
 
-script: travis_wait 30 data_import_post_install_tests.sh
+script: data_import_post_install_tests.sh

--- a/data_import_post_install_tests.sh
+++ b/data_import_post_install_tests.sh
@@ -43,7 +43,7 @@ fi
 export study_accession_num="E-ENAD-14"
 export matrix_type="cpm"
 export output_dir_name=$test_dir/$study_accession_num
-export num_clusters=24
+export num_clusters=22
 export classifiers_output_dir=$test_dir/"imported_classifiers"
 export tool="scmap-cell"
 export condensed_sdrfs="TRUE"

--- a/get_experiment_data.R
+++ b/get_experiment_data.R
@@ -156,6 +156,7 @@ download.file.with.retries <- function(link, dest, sleep_time=5, max_retries=5){
     stat <- 1
     retries <- 0
 
+    print(paste("Downloading", link))
     while( stat != 0 && retries < max_retries){
         if (retries > 0){
             Sys.sleep(sleep_time)
@@ -168,6 +169,7 @@ download.file.with.retries <- function(link, dest, sleep_time=5, max_retries=5){
         write(paste("Unable to download", link, 'after', max_retries, 'retries'), stderr())
         quit(status=1)
     }
+    print("... success")
 }
 
 # download expression data

--- a/get_experiment_data.R
+++ b/get_experiment_data.R
@@ -153,12 +153,13 @@ if(matrix_type == "RAW"){
 
 # Wrap download.file for retries and error checking
 download.file.with.retries <- function(link, dest, sleep_time=5, max_retries=5){
-    Sys.sleep(sleep_time)    
-    
     stat <- 1
     retries <- 0
 
     while( stat != 0 && retries < max_retries){
+        if (retries > 0){
+            Sys.sleep(sleep_time)
+        }    
         stat <- download.file(link, destfile=dest)
         retries <- retries + 1
     }

--- a/import_classification_data.R
+++ b/import_classification_data.R
@@ -98,12 +98,13 @@ if(!dir.exists(classifier_out_dir)){
 
 # Wrap download.file for retries and error checking
 download.file.with.retries <- function(link, dest, sleep_time=5, max_retries=5){
-    Sys.sleep(sleep_time)    
-    
     stat <- 1
     retries <- 0
 
     while( stat != 0 && retries < max_retries){
+        if (retries > 0){
+            Sys.sleep(sleep_time)
+        }    
         stat <- download.file(link, destfile=dest)
         retries <- retries + 1
     }

--- a/import_classification_data.R
+++ b/import_classification_data.R
@@ -101,6 +101,7 @@ download.file.with.retries <- function(link, dest, sleep_time=5, max_retries=5){
     stat <- 1
     retries <- 0
 
+    print(paste("Downloading", link))
     while( stat != 0 && retries < max_retries){
         if (retries > 0){
             Sys.sleep(sleep_time)
@@ -113,6 +114,7 @@ download.file.with.retries <- function(link, dest, sleep_time=5, max_retries=5){
         write(paste("Unable to download", link, 'after', max_retries, 'retries'), stderr())
         quit(status=1)
     }
+    print("... success")
 }
 
 # download classifiers from specified datasets


### PR DESCRIPTION
Add a retry strategy for classifier downloads. 

Obviously I shouldn't be duplicating the function, but I've forgotten how to source a file from the same dir as a script, and time is short.